### PR TITLE
Alt text for images & the canvas

### DIFF
--- a/gbtdg.js
+++ b/gbtdg.js
@@ -372,6 +372,7 @@ $(document).ready(function() {
 					canvas_context.globalCompositeOperation = "destination-out";
 					canvas_context.clearRect(0, 0, canvas.width, canvas.height);
 					canvas_context.restore();
+					$("canvas#canvas")[0].textContent = "";
 
 					// Draw Image on Visisble Canvas
 					canvas_context.drawImage(image, 0, 0, image.width, image.height, x, y, new_width, new_height);

--- a/gbtdg.js
+++ b/gbtdg.js
@@ -157,10 +157,10 @@ $(document).ready(function() {
 			var hidden_img = new Image();
 			hidden_img.src = e.target.result;
 
-		  hidden_img.onload = function() {
+			hidden_img.onload = function() {
 
 				// Error check: Pixel dimensions
-		  	if(hidden_img.width > max_width || hidden_img.height > max_height) {
+				if(hidden_img.width > max_width || hidden_img.height > max_height) {
 					alert("Image dimensions are too large.\nMaximum width is " + 
 						max_width + "px and maximum height is " + max_height + "px.");
 					return;
@@ -227,28 +227,28 @@ $(document).ready(function() {
 				hidden_canvas_context.fillRect(0, 0, image_pw, image_ph);
 
 				// Draw Image on Hidden Canvas
-		    hidden_canvas_context.drawImage(hidden_img, 0, 0);
+				hidden_canvas_context.drawImage(hidden_img, 0, 0);
 
-		    // Get Image Pixel Data ------------------------------------------------
-		    
+				// Get Image Pixel Data ------------------------------------------------
+
 				var imageData = hidden_canvas_context.getImageData(0, 0, image_pw, image_ph);
 
 				var pixelData = [];
 
 				// Convert tile data to grayscale
 				for(var y = 0; y < image_ph; y++) {
-				  for(var x = 0; x < image_pw; x++) {
-				  	var index = ((y * image_pw) * 4) + (x * 4);
+					for(var x = 0; x < image_pw; x++) {
+						var index = ((y * image_pw) * 4) + (x * 4);
 
-				  	// Read RGB Data
-				  	var r = imageData.data[index];
-				  	var g = imageData.data[index + 1];
-				  	var b = imageData.data[index + 2];
-				    
-				    var val = ((r * 0.3) + (g * 0.59) + (b * 0.11));
-				    var new_val;
+						// Read RGB Data
+						var r = imageData.data[index];
+						var g = imageData.data[index + 1];
+						var b = imageData.data[index + 2];
 
-				    // Convert grayscale value to 4 color value
+						var val = ((r * 0.3) + (g * 0.59) + (b * 0.11));
+						var new_val;
+
+						// Convert grayscale value to 4 color value
 						if(val >= 0 && val < 85) {
 							if(val < 65) {
 								new_val = 0;
@@ -267,7 +267,7 @@ $(document).ready(function() {
 							}
 						} else if(val >= 170 && val <= 255) {
 							if(val < 193) {
-								new_val =  170;
+								new_val = 170;
 								pixelData.push(2);
 							} else {
 								new_val = 255;
@@ -275,11 +275,11 @@ $(document).ready(function() {
 							}
 						}
 
-				    // Save Greyscale RGB Data
-				    imageData.data[index] = new_val;
-				    imageData.data[index + 1] = new_val;
-				    imageData.data[index + 2] = new_val;
-				  }
+						// Save Greyscale RGB Data
+						imageData.data[index] = new_val;
+						imageData.data[index + 1] = new_val;
+						imageData.data[index + 2] = new_val;
+					}
 				}
 
 				// Apply Greyscale Image to Hidden Canvas
@@ -288,41 +288,41 @@ $(document).ready(function() {
 				// Generate Tile Data --------------------------------------------------
 				
 				for(var y_tile = 0; y_tile < image_th; y_tile++) {
-				  for(var x_tile = 0; x_tile < image_tw; x_tile++) {
+					for(var x_tile = 0; x_tile < image_tw; x_tile++) {
 
-				  	var tile_index = ((y_tile * image_tw) + x_tile);
-				  	tileData[tile_index] = [];
+						var tile_index = ((y_tile * image_tw) + x_tile);
+						tileData[tile_index] = [];
 
-				  	for(var y_pixel = 0; y_pixel < tile_ph; y_pixel++) {
+						for(var y_pixel = 0; y_pixel < tile_ph; y_pixel++) {
 
-				  		var byte_0 = 0x00;
-				  		var byte_1 = 0x00;
+							var byte_0 = 0x00;
+							var byte_1 = 0x00;
 
-				  		var bitmask = 0x80;
+							var bitmask = 0x80;
 
-				  		for(var x_pixel = 0; x_pixel < tile_pw; x_pixel++) {
-				  			var index = (((y_tile * tile_ph) + y_pixel) * image_pw) + ((x_tile * tile_pw) + x_pixel);
-				  			var pixel = pixelData[index];
+							for(var x_pixel = 0; x_pixel < tile_pw; x_pixel++) {
+								var index = (((y_tile * tile_ph) + y_pixel) * image_pw) + ((x_tile * tile_pw) + x_pixel);
+								var pixel = pixelData[index];
 
-				  			if(pixel === 0) {
-				  				// Black
-				  				byte_0 = byte_0 | bitmask;
-				  				byte_1 = byte_1 | bitmask;
-				  			} else if(pixel === 1) {
-				  				// Dark Grey
-				  				byte_1 = byte_1 | bitmask;
-				  			} else if(pixel === 2) {
-				  				// Light Grey
-				  				byte_0 = byte_0 | bitmask;
-				  			} else {
-				  				// White
-				  			}
-				  			bitmask = bitmask >> 1;
-				  		}
-				  		tileData[tile_index].push(byte_0, byte_1);
-				  	}
-				  	mapData.push(tile_index);
-				  }
+								if(pixel === 0) {
+									// Black
+									byte_0 = byte_0 | bitmask;
+									byte_1 = byte_1 | bitmask;
+								} else if(pixel === 1) {
+									// Dark Grey
+									byte_1 = byte_1 | bitmask;
+								} else if(pixel === 2) {
+									// Light Grey
+									byte_0 = byte_0 | bitmask;
+								} else {
+									// White
+								}
+								bitmask = bitmask >> 1;
+							}
+							tileData[tile_index].push(byte_0, byte_1);
+						}
+						mapData.push(tile_index);
+					}
 				}
 
 				// Generate and Display Output -----------------------------------------
@@ -331,15 +331,15 @@ $(document).ready(function() {
 
 				// Apply Image to Visible Canvas ---------------------------------------
 				
-		    var image = new Image();
-		    image.src = $("canvas#hidden-canvas")[0].toDataURL();
+				var image = new Image();
+				image.src = $("canvas#hidden-canvas")[0].toDataURL();
 
-		    var new_width;
+				var new_width;
 				var new_height;
 
-		    image.onload = function() {
+				image.onload = function() {
 
-			  	// Determine Image Dimensions for Visible Canvas
+					// Determine Image Dimensions for Visible Canvas
 					if((image.width > canvas.width && image.height < canvas.height) ||
 					   (image.width > canvas.width && image.height > canvas.height && image.width > image.height)) {
 
@@ -349,12 +349,12 @@ $(document).ready(function() {
 					} else if((image.width < canvas.width && image.height > canvas.height) || 
 						(image.width > canvas.width && image.height > canvas.height && image.width < image.height)) {
 
-						new_width 	= Math.ceil((canvas.height * image.width) / image.height);
-						new_height  = canvas.height;
+						new_width  = Math.ceil((canvas.height * image.width) / image.height);
+						new_height = canvas.height;
 
 					} else if(image.width > canvas.width && image.height > canvas.width && image.width === image.height) {
 
-						new_width = canvas.width;
+						new_width  = canvas.width;
 						new_height = canvas.height;
 
 					} else if (image.width <= canvas.width && image.height <= canvas.height) {
@@ -368,7 +368,7 @@ $(document).ready(function() {
 					var y = Math.floor((canvas.height - new_height) / 2);
 
 					// Clear Visible Canvas
-		  		canvas_context.save();
+					canvas_context.save();
 					canvas_context.globalCompositeOperation = "destination-out";
 					canvas_context.clearRect(0, 0, canvas.width, canvas.height);
 					canvas_context.restore();
@@ -376,7 +376,7 @@ $(document).ready(function() {
 					// Draw Image on Visisble Canvas
 					canvas_context.drawImage(image, 0, 0, image.width, image.height, x, y, new_width, new_height);
 				}
-		  }
+			}
 		}
 	});
 });
@@ -476,11 +476,11 @@ function advancedOptionsControl() {
 				animating = true;
 
 				$("div#advanced-options").animate({left:0}, advanced_options_duration, function() {
-	      	animating = false;
-	      	advanced_options = true;
-	      });
+					animating = false;
+					advanced_options = true;
+				});
 
-	      $(this).html(advanced_options_text_hide);
+				$(this).html(advanced_options_text_hide);
 
 				$("div#app-container").click(function(e) {
 					e.stopPropagation();
@@ -623,8 +623,8 @@ function optionsTextInputsHandler() {
 			    e.keyCode !== 46 && // Delete
 			   (e.keyCode < 37 || e.keyCode > 57)){ // 0-9
 
-        return false;
-      }
+				return false;
+			}
 		});
 	});
 
@@ -643,8 +643,8 @@ function optionsTextInputsHandler() {
 			    e.keyCode !== 46 && // Delete
 			   (e.keyCode < 37 || e.keyCode > 70)){ // 0-9, a-f
 
-        return false;
-      }
+				return false;
+			}
 		});
 	});
 }
@@ -768,7 +768,7 @@ function generateOutput() {
 		var actual_mapData_length;
 
 		// Get Options Values
-    getOptionsValues();
+		getOptionsValues();
 
 		// Clear Output Buffer
 		output_buffer = "";
@@ -1048,10 +1048,10 @@ function trimString(_str, _l) {
 	var str = _str;
 	var sl;
 	if(str.length > _l) {
-  	var sl = Math.floor((_l / 2) - 2);
-  	str = str.substr(0, sl) + "..." + str.substr(-sl, sl);
-  }
-  return str;
+		var sl = Math.floor((_l / 2) - 2);
+		str = str.substr(0, sl) + "..." + str.substr(-sl, sl);
+	}
+	return str;
 }
 
 /** ----------------------------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 	<!-- Header -->
 	<div>
 		<header>
-			<span><img src="img/gameboy-logo.gif" />&trade; Tile Data Generator v1.3.1</span>
+			<span><img src="img/gameboy-logo.gif" alt="GAMEBOY" />&trade; Tile Data Generator v1.3.1</span>
 			<a href="#" class="text-page">Instructions</a>
 		</header>
 	</div>
@@ -49,34 +49,34 @@
 					<p>
 						<table id="compatibility" cellspacing="0">
 							<tr>
-								<td class="icon"><img src="img/windows.gif" title="Windows XP, 7, 8" /><td>
-								<td class="icon"><img src="img/chrome.gif" title="Google Chrome 22" /><td>
-								<td class="icon"><img src="img/firefox.gif" title="Mozilla Firefox 16" /><td>
-								<td class="icon"><img src="img/opera.gif" title="Opera 12" /><td>
-								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 5.2"/><td>
-								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9" /><td>
+								<td class="icon"><img src="img/windows.gif" title="Windows XP, 7, 8" alt="Windows" /><td>
+								<td class="icon"><img src="img/chrome.gif" title="Google Chrome 22" alt="Chrome" /><td>
+								<td class="icon"><img src="img/firefox.gif" title="Mozilla Firefox 16" alt="Firefox" /><td>
+								<td class="icon"><img src="img/opera.gif" title="Opera 12" alt="Opera" /><td>
+								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 5.2" alt="Safari" /><td>
+								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9" alt="Internet Explorer" /><td>
 								<td>
 									<span>Note:</span> Safari 5.2 and IE 9 do not support <a href="http://caniuse.com/#feat=fileapi" target="_blank">HTML5 File API</a> or <a href="http://caniuse.com/filereader" target="_blank">FileReader</a> at this time.
 								</td>
 							</tr>
 							<tr>
-								<td class="icon"><img src="img/osx.gif" title="OSX" /><td>
-								<td class="icon"><img class="broken" src="img/chrome.gif" title="Google Chrome 22" /><td>
-								<td class="icon"><img class="broken" src="img/firefox.gif" title="Mozilla Firefox 16" /><td>
-								<td class="icon"><img class="broken" src="img/opera.gif" title="Opera 12" /><td>
-								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 6" /><td>
-								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9"/><td>
+								<td class="icon"><img src="img/osx.gif" title="OSX" alt="OSX" /><td>
+								<td class="icon"><img class="broken" src="img/chrome.gif" title="Google Chrome 22" alt="Chrome" /><td>
+								<td class="icon"><img class="broken" src="img/firefox.gif" title="Mozilla Firefox 16" alt="Firefox" /><td>
+								<td class="icon"><img class="broken" src="img/opera.gif" title="Opera 12" alt="Opera" /><td>
+								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 6" alt="Safari" /><td>
+								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9" alt="Internet Explorer" /><td>
 								<td>
 									No browser testing has been performed.
 								</td>
 							</tr>
 							<tr>
 								<td class="icon" style="text-align: center;"><img src="img/NewTux.svg" style="width:30px;" title="Linux" /><td>
-								<td class="icon"><img src="img/chrome.gif" title="Google Chrome 22" /><td>
-								<td class="icon"><img src="img/firefox.gif" title="Mozilla Firefox 16" /><td>
-								<td class="icon"><img class="broken" src="img/opera.gif" title="Opera 12" /><td>
-								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 6" /><td>
-								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9"/><td>
+								<td class="icon"><img src="img/chrome.gif" title="Google Chrome 22" alt="Chrome" /><td>
+								<td class="icon"><img src="img/firefox.gif" title="Mozilla Firefox 16" alt="Firefox" /><td>
+								<td class="icon"><img class="broken" src="img/opera.gif" title="Opera 12" alt="Opera" /><td>
+								<td class="icon"><img class="broken" src="img/safari.gif" title="Safari 6" alt="Safari" /><td>
+								<td class="icon"><img class="broken" src="img/ie.gif" title="Internet Explorer 9" alt="Internet Explorer" /><td>
 								<td>
 									Unsupported browsers are not available for Linux.
 								</td>
@@ -239,7 +239,7 @@
 	<div>
 		<footer>
 			<span>
-				Nintendo&reg; GameBoy&trade; and <img src="img/gameboy-logo-small.gif" />&trade; are registered trademarks of Nintendo&reg; Inc.<br />
+				Nintendo&reg; GameBoy&trade; and <img src="img/gameboy-logo-small.gif" alt="GAMEBOY" />&trade; are registered trademarks of Nintendo&reg; Inc.<br />
 				v1.3.1 &sdot; <a href="http://chrisantonellis.com">Chris Antonellis</a> &sdot; <a href="https://github.com/chrisantonellis/gbtdg/">GitHub</a>
 			</span>
 		</footer>

--- a/index.html
+++ b/index.html
@@ -147,7 +147,9 @@
 				<!-- Input Image -->
 				<h1>Input Image</h1>
 				<figure>
-					<canvas id="canvas" width="160" height="144"></canvas>
+					<canvas id="canvas" width="160" height="144">
+						Please Click to Select an Image
+					</canvas>
 				</figure>
 
 				<!-- Image Attributes -->

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 								</td>
 							</tr>
 							<tr>
-								<td class="icon" style="text-align: center;"><img src="img/NewTux.svg" style="width:30px;" title="Linux" /><td>
+								<td class="icon" style="text-align: center;"><img src="img/NewTux.svg" style="width:30px;" title="Linux" alt="Linux" /><td>
 								<td class="icon"><img src="img/chrome.gif" title="Google Chrome 22" alt="Chrome" /><td>
 								<td class="icon"><img src="img/firefox.gif" title="Mozilla Firefox 16" alt="Firefox" /><td>
 								<td class="icon"><img class="broken" src="img/opera.gif" title="Opera 12" alt="Opera" /><td>


### PR DESCRIPTION
This adds alt text to all images, as mandated by html5.

This mainly makes it so that you can more easily copy the bits of text that have a GAMEBOY logo in them by just selecting them.
Since the canvas alt content needs to be cleared, there's 1 new line of js that does that.
While in the file, I decided to fix up all the places where the indentation used two spaces instead of a tab.
(except for things where spaces are used to neatly line things up)